### PR TITLE
Require clojure.string instead of using it directly

### DIFF
--- a/src/com/wsscode/pathom/profile.cljc
+++ b/src/com/wsscode/pathom/profile.cljc
@@ -1,5 +1,6 @@
 (ns com.wsscode.pathom.profile
   (:require
+    [clojure.string :as str]
     [clojure.core.async :refer [<! go chan put!]]
     [#?(:clj  com.wsscode.common.async-clj
         :cljs com.wsscode.common.async-cljs) :refer [let-chan]]
@@ -56,7 +57,7 @@
 
 (defn node-name [x]
   (cond
-    (vector? x) (clojure.string/join "_" (map node-name x))
+    (vector? x) (str/join "_" (map node-name x))
     :else (str x)))
 
 (defn node-value [x]


### PR DESCRIPTION
While compiling I get: 


```
------ WARNING #1 - :undeclared-var --------------------------------------------
 Resource: com/wsscode/pathom/profile.cljc:59:18
--------------------------------------------------------------------------------
  56 | 
  57 | (defn node-name [x]
  58 |   (cond
  59 |     (vector? x) (clojure.string/join "_" (map node-name x))
------------------------^-------------------------------------------------------
 Use of undeclared Var clojure.string/join
--------------------------------------------------------------------------------
```

This MR fixes this by properly requiring `clojure.string`.