### PR TITLE
feat: consider params in request caching

### DIFF
--- a/test/com/wsscode/pathom/connect_test.cljc
+++ b/test/com/wsscode/pathom/connect_test.cljc
@@ -852,10 +852,10 @@
     (is (= (parser {::p/entity (atom {:user/id 1 :user/foo "bar"})}
              [:user/name :cache])
            {:user/name "Mel"
-            :cache     {[`user-by-id {:user/id 1}] {:user/age   26
-                                                    :user/id    1
-                                                    :user/login "meel"
-                                                    :user/name  "Mel"}}})))
+            :cache     {[`user-by-id {:user/id 1} nil] {:user/age   26
+                                                        :user/id    1
+                                                        :user/login "meel"
+                                                        :user/name  "Mel"}}})))
 
   (testing "doesn't cache if asked to cache? is false"
     (is (= (parser {} [:value :cache])
@@ -1017,10 +1017,10 @@
     (is (= (parser2 {::p/entity (atom {:user/id 1 :user/foo "bar"})}
              [:user/name :cache])
            {:user/name "Mel"
-            :cache     {[`user-by-id {:user/id 1}] {:user/age   26
-                                                    :user/id    1
-                                                    :user/login "meel"
-                                                    :user/name  "Mel"}}})))
+            :cache     {[`user-by-id {:user/id 1} nil] {:user/age   26
+                                                        :user/id    1
+                                                        :user/login "meel"
+                                                        :user/name  "Mel"}}})))
 
   (testing "doesn't cache if asked to cache? is false"
     (is (= (parser2 {} [:value :cache])
@@ -2511,7 +2511,7 @@
                    :com.wsscode.pathom.trace/event     :com.wsscode.pathom.connect/compute-plan}]))))
 
      (testing "use cache when available"
-       (is (= (call-parallel-reader {::p/request-cache (atom {['a {}] (go-promise {:a 3})})} :b)
+       (is (= (call-parallel-reader {::p/request-cache (atom {['a {} nil] (go-promise {:a 3})})} :b)
               #:com.wsscode.pathom.parser{:provides        #{:a :b}
                                           :response-stream [#:com.wsscode.pathom.parser{:provides       #{:a}
                                                                                         :response-value {:a 3}}
@@ -2537,7 +2537,8 @@
                  :com.wsscode.pathom.trace/event        :com.wsscode.pathom.connect/call-resolver-with-cache
                  :key                                   :b}
                 {:com.wsscode.pathom.core/cache-key [a
-                                                     {}]
+                                                     {}
+                                                     nil]
                  :com.wsscode.pathom.core/path      [:b]
                  :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-hit}
                 {:com.wsscode.pathom.connect/sym a
@@ -2550,7 +2551,8 @@
                  :com.wsscode.pathom.trace/event        :com.wsscode.pathom.connect/call-resolver-with-cache
                  :key                                   :b}
                 {:com.wsscode.pathom.core/cache-key [a->b
-                                                     {:a 3}]
+                                                     {:a 3}
+                                                     nil]
                  :com.wsscode.pathom.core/path      [:b]
                  :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                 {:com.wsscode.pathom.connect/input-data {:a 3}
@@ -2578,11 +2580,14 @@
                                                                                           :response-value {:l "a"}}]}))
          (is (= (into {} (map (fn [[k v]] [k (async/<!! v)])) @cache)
                 '{[i->l
-                   {:i 1}] {:l "a"}
+                   {:i 1}
+                   nil] {:l "a"}
                   [i->l
-                   {:i 2}] {:l "b"}
+                   {:i 2}
+                   nil] {:l "b"}
                   [i->l
-                   {:i 3}] {:l "c"}}))
+                   {:i 3}
+                   nil] {:l "c"}}))
 
          (is (= (comparable-trace @trace)
                 '[{:com.wsscode.pathom.core/path       [:l]
@@ -2606,15 +2611,18 @@
                    :com.wsscode.pathom.core/path     [:l]
                    :com.wsscode.pathom.trace/event   :com.wsscode.pathom.connect/batch-items-ready}
                   {:com.wsscode.pathom.core/cache-key [i->l
-                                                       {:i 1}]
+                                                       {:i 1}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:l]
                    :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                   {:com.wsscode.pathom.core/cache-key [i->l
-                                                       {:i 2}]
+                                                       {:i 2}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:l]
                    :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                   {:com.wsscode.pathom.core/cache-key [i->l
-                                                       {:i 3}]
+                                                       {:i 3}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:l]
                    :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                   {:com.wsscode.pathom.connect/input-data [{:i 1}
@@ -2849,11 +2857,14 @@
                                                                                           :response-value {:error-batch :com.wsscode.pathom.core/reader-error}}]}))
          (is (= (into {} (map (fn [[k v]] [k (async/<!! v)])) @cache)
                 '{[error-batch
-                   {:i 1}] {:error-batch :com.wsscode.pathom.core/reader-error}
+                   {:i 1}
+                   nil] {:error-batch :com.wsscode.pathom.core/reader-error}
                   [error-batch
-                   {:i 2}] {:error-batch :com.wsscode.pathom.core/reader-error}
+                   {:i 2}
+                   nil] {:error-batch :com.wsscode.pathom.core/reader-error}
                   [error-batch
-                   {:i 3}] {:error-batch :com.wsscode.pathom.core/reader-error}}))
+                   {:i 3}
+                   nil] {:error-batch :com.wsscode.pathom.core/reader-error}}))
 
          (is (= @errors {[:list
                           0
@@ -2895,19 +2906,22 @@
                                                       :error-batch]
                    :com.wsscode.pathom.trace/event   :com.wsscode.pathom.connect/batch-items-ready}
                   {:com.wsscode.pathom.core/cache-key [error-batch
-                                                       {:i 1}]
+                                                       {:i 1}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:list
                                                        0
                                                        :error-batch]
                    :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                   {:com.wsscode.pathom.core/cache-key [error-batch
-                                                       {:i 2}]
+                                                       {:i 2}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:list
                                                        0
                                                        :error-batch]
                    :com.wsscode.pathom.trace/event    :com.wsscode.pathom.core/cache-miss}
                   {:com.wsscode.pathom.core/cache-key [error-batch
-                                                       {:i 3}]
+                                                       {:i 3}
+                                                       nil]
                    :com.wsscode.pathom.core/path      [:list
                                                        0
                                                        :error-batch]


### PR DESCRIPTION
This commit introduces (naive) parameter consideration to request
caching - meaning that parameters will be considered when deciding
whether to use an existing cached value.

The approach is naive in that it does not consider defaults, so
additional work might be performed if a user requests something w/ the
same parameters as the defaults. That being said, in a "real-world"
workload, this seems extremely unlikely. Furthermore, with the existing API, I cannot imagine an ergonomic way of introducing the functionality.

All tests in connect are reported as passing, with the exception of an assertion that was already broken because it is using a single argument to `=` in the assertion.