### PR TITLE
Allow passing custom inner graphql parser

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -3884,6 +3884,13 @@ adapting `pcg/parser-item` to also coerce `:my.gql.item/id` values to uuids:
                              (-> (merge {::demung identity} env)
                                  (update ::p/placeholder-prefixes
                                          #(or % #{})))))]}))
+
+(def my-gql-config
+  {::pcg/url         "https://api.mydomain.com/graphql"
+   ::pcg/prefix      "my.gql"
+   ::pcg/parser-item parser-item
+   ::pcg/ident-map   {"item" {"id" :my.gql.item/id}}
+   ::p.http/driver   p.http.fetch/request-async})
 ----
 
 This is only lightly edited from the implementation of `pcg/parser-item`.

--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1177,10 +1177,10 @@ In case there are multiple possible paths Pathom has to decide which path to tak
 the current implementation chooses the path with less weight, that calculation is made
 in this way:
 
-1. Every resolver starts with weight 1 (this is recorded per instance)
-1. Once a resolver is called, it’s execution time is recorded and updated in the map using the formula: new-value = (old-value + last-time) * 0.5
-1. If a resolver call throws an exception, double it’s weight
-1. Every time we mention some resolver in a path calculation its weight is reduced by one.
+. Every resolver starts with weight 1 (this is recorded per instance)
+. Once a resolver is called, it’s execution time is recorded and updated in the map using the formula: new-value = (old-value + last-time) * 0.5
+. If a resolver call throws an exception, double it’s weight
+. Every time we mention some resolver in a path calculation its weight is reduced by one.
 
 If you like to make your own sorting of the plan, you can set the key `::pc/sort-plan` in your
 environment, and Pathom will call this function sort the results, it takes the environment
@@ -3821,6 +3821,72 @@ Now we can write a reasonable query that contains everything we need:
 ```
 
 and we're good to go!
+
+==== Customizing Result Parsing [[CustomResultParsing]]
+
+Under the hood, Pathom uses a <<Readers,parser reader>> to do some error
+handling and bookkeeping on the query result. The simplest way to customize
+query results is to pass in custom `mung` and `demung` functions. These can be
+added as optional keys to the GraphQL configuration map. For example, if our
+EQL query keywords are in kebab case, but the GraphQL schema uses camel case,
+we can make the Connect plugin do the conversion for us with the following
+configuration:
+
+[source,clojure]
+----
+(def github-gql
+  {::pcg/url       (str "https://api.github.com/graphql?access_token=" (ls/get :github-token))
+   ::pcg/prefix    "github"
+   ::pcg/mung      pg/kebab-case
+   ::pcg/demung    pg/camel-case
+   ::pcg/ident-map {"user"       {"login" :github.User/login}
+                    "repository" {"owner" :github.User/login
+                                  "name"  :github.Repository/name}}
+   ::p.http/driver p.http.fetch/request-async})
+----
+
+We can completely customize the query results by passing our own custom parser.
+See `pcg/parser-item` as an example of what such a parser should look like. This
+could be used to coerce uuid values from strings to uuids. Here's an example of
+adapting `pcg/parser-item` to also coerce `:my.gql.item/id` values to uuids:
+
+[source,clojure]
+----
+(defn demunger-map-reader
+  "Reader that will demunge keys and coerce :my.gql.item/id values to uuids"
+  [{::keys [demung]
+    :keys  [ast query]
+    :as    env}]
+  (let [entity (p/entity env)
+        k (:key ast)]
+    (if-let [[_ v] (find entity (pcg/demung-key demung k))]
+      (do
+        (if (sequential? v)
+          (if query
+            (p/join-seq env v)
+            (if (= k :my.gql.item/id)
+              (map uuid v)
+              v))
+          (if (and (map? v) query)
+            (p/join v env)
+            (if (= k :my.gql.item/id)
+              (uuid v)
+              v))))
+      ::p/continue)))
+
+(def parser-item
+  (p/parser {::p/env     {::p/reader [pcg/error-stamper
+                                      demunger-map-reader
+                                      p/env-placeholder-reader
+                                      pcg/gql-ident-reader]}
+             ::p/plugins [(p/env-wrap-plugin
+                           (fn [env]
+                             (-> (merge {::demung identity} env)
+                                 (update ::p/placeholder-prefixes
+                                         #(or % #{})))))]}))
+----
+
+This is only lightly edited from the implementation of `pcg/parser-item`.
 
 === Complete GraphQL Connect Example
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -6126,7 +6126,7 @@ adapting <code>pcg/parser-item</code> to also coerce <code>:my.gql.item/id</code
 <div class="listingblock">
 <div class="content">
 <pre class="CodeRay highlight"><code data-lang="clojure">(<span class="keyword">defn</span> <span class="function">demunger-map-reader</span>
-  <span class="string"><span class="delimiter">&quot;</span><span class="content">Reader that will demunge keys and coerce :github.User/id values to uuids</span><span class="delimiter">&quot;</span></span>
+  <span class="string"><span class="delimiter">&quot;</span><span class="content">Reader that will demunge keys and coerce :my.gql.item/id values to uuids</span><span class="delimiter">&quot;</span></span>
   [{<span class="symbol">::keys</span> [demung]
     <span class="symbol">:keys</span>  [ast query]
     <span class="symbol">:as</span>    env}]
@@ -6156,7 +6156,14 @@ adapting <code>pcg/parser-item</code> to also coerce <code>:my.gql.item/id</code
                            (<span class="keyword">fn</span> [env]
                              (<span class="keyword">-&gt;</span> (<span class="keyword">merge</span> {<span class="symbol">::demung</span> <span class="keyword">identity</span>} env)
                                  (update <span class="symbol">::p/placeholder-prefixes</span>
-                                         #(<span class="keyword">or</span> % #{})))))]}))</code></pre>
+                                         #(<span class="keyword">or</span> % #{})))))]}))
+
+(<span class="keyword">def</span> <span class="function">my-gql-config</span>
+  {<span class="symbol">::pcg/url</span>         <span class="string"><span class="delimiter">&quot;</span><span class="content">https://api.mydomain.com/graphql</span><span class="delimiter">&quot;</span></span>
+   <span class="symbol">::pcg/prefix</span>      <span class="string"><span class="delimiter">&quot;</span><span class="content">my.gql</span><span class="delimiter">&quot;</span></span>
+   <span class="symbol">::pcg/parser-item</span> parser-item
+   <span class="symbol">::pcg/ident-map</span>   {<span class="string"><span class="delimiter">&quot;</span><span class="content">item</span><span class="delimiter">&quot;</span></span> {<span class="string"><span class="delimiter">&quot;</span><span class="content">id</span><span class="delimiter">&quot;</span></span> <span class="symbol">:my.gql.item/id</span>}}
+   <span class="symbol">::p.http/driver</span>   p.http.fetch/request-async})</code></pre>
 </div>
 </div>
 <div class="paragraph">
@@ -6334,7 +6341,7 @@ and see the GraphQL equivalent been generated on the right.</p>
 <div id="footer">
 <div id="footer-text">
 Version 2<br>
-Last updated 2019-04-20 22:31:32 EDT
+Last updated 2019-04-20 22:51:49 EDT
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6093,6 +6093,76 @@ defining a helper function:</p>
 <p>and we&#8217;re good to go!</p>
 </div>
 </div>
+<div class="sect4">
+<h5 id="CustomResultParsing"><a class="anchor" href="#CustomResultParsing"></a><a class="link" href="#CustomResultParsing">Customizing Result Parsing</a></h5>
+<div class="paragraph">
+<p>Under the hood, Pathom uses a <a href="#Readers">parser reader</a> to do some error
+handling and bookkeeping on the query result. The simplest way to customize
+query results is to pass in custom <code>mung</code> and <code>demung</code> functions. These can be
+added as optional keys to the GraphQL configuration map. For example, if our
+EQL query keywords are in kebab case, but the GraphQL schema uses camel case,
+we can make the Connect plugin do the conversion for us with the following
+configuration:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="clojure">(<span class="keyword">def</span> <span class="function">github-gql</span>
+  {<span class="symbol">::pcg/url</span>       (<span class="keyword">str</span> <span class="string"><span class="delimiter">&quot;</span><span class="content">https://api.github.com/graphql?access_token=</span><span class="delimiter">&quot;</span></span> (ls/get <span class="symbol">:github-token</span>))
+   <span class="symbol">::pcg/prefix</span>    <span class="string"><span class="delimiter">&quot;</span><span class="content">github</span><span class="delimiter">&quot;</span></span>
+   <span class="symbol">::pcg/mung</span>      pg/kebab-case
+   <span class="symbol">::pcg/demung</span>    pg/camel-case
+   <span class="symbol">::pcg/ident-map</span> {<span class="string"><span class="delimiter">&quot;</span><span class="content">user</span><span class="delimiter">&quot;</span></span>       {<span class="string"><span class="delimiter">&quot;</span><span class="content">login</span><span class="delimiter">&quot;</span></span> <span class="symbol">:github.User/login</span>}
+                    <span class="string"><span class="delimiter">&quot;</span><span class="content">repository</span><span class="delimiter">&quot;</span></span> {<span class="string"><span class="delimiter">&quot;</span><span class="content">owner</span><span class="delimiter">&quot;</span></span> <span class="symbol">:github.User/login</span>
+                                  <span class="string"><span class="delimiter">&quot;</span><span class="content">name</span><span class="delimiter">&quot;</span></span>  <span class="symbol">:github.Repository/name</span>}}
+   <span class="symbol">::p.http/driver</span> p.http.fetch/request-async})</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>We can completely customize the query results by passing our own custom parser.
+See <code>pcg/parser-item</code> as an example of what such a parser should look like. This
+could be used to coerce uuid values from strings to uuids. Here&#8217;s an example of
+adapting <code>pcg/parser-item</code> to also coerce <code>:my.gql.item/id</code> values to uuids:</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="CodeRay highlight"><code data-lang="clojure">(<span class="keyword">defn</span> <span class="function">demunger-map-reader</span>
+  <span class="string"><span class="delimiter">&quot;</span><span class="content">Reader that will demunge keys and coerce :github.User/id values to uuids</span><span class="delimiter">&quot;</span></span>
+  [{<span class="symbol">::keys</span> [demung]
+    <span class="symbol">:keys</span>  [ast query]
+    <span class="symbol">:as</span>    env}]
+  (<span class="keyword">let</span> [entity (p/entity env)
+        k (<span class="symbol">:key</span> ast)]
+    (<span class="keyword">if-let</span> [[_ v] (<span class="keyword">find</span> entity (pcg/demung-key demung k))]
+      (<span class="keyword">do</span>
+        (<span class="keyword">if</span> (<span class="keyword">sequential?</span> v)
+          (<span class="keyword">if</span> query
+            (p/join-seq env v)
+            (<span class="keyword">if</span> (<span class="keyword">=</span> k <span class="symbol">:my.gql.item/id</span>)
+              (<span class="keyword">map</span> uuid v)
+              v))
+          (<span class="keyword">if</span> (<span class="keyword">and</span> (<span class="keyword">map?</span> v) query)
+            (p/join v env)
+            (<span class="keyword">if</span> (<span class="keyword">=</span> k <span class="symbol">:my.gql.item/id</span>)
+              (uuid v)
+              v))))
+      <span class="symbol">::p/continue</span>)))
+
+(<span class="keyword">def</span> <span class="function">parser-item</span>
+  (p/parser {<span class="symbol">::p/env</span>     {<span class="symbol">::p/reader</span> [pcg/error-stamper
+                                      demunger-map-reader
+                                      p/env-placeholder-reader
+                                      pcg/gql-ident-reader]}
+             <span class="symbol">::p/plugins</span> [(p/env-wrap-plugin
+                           (<span class="keyword">fn</span> [env]
+                             (<span class="keyword">-&gt;</span> (<span class="keyword">merge</span> {<span class="symbol">::demung</span> <span class="keyword">identity</span>} env)
+                                 (update <span class="symbol">::p/placeholder-prefixes</span>
+                                         #(<span class="keyword">or</span> % #{})))))]}))</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>This is only lightly edited from the implementation of <code>pcg/parser-item</code>.</p>
+</div>
+</div>
 </div>
 <div class="sect3">
 <h4 id="_complete_graphql_connect_example"><a class="anchor" href="#_complete_graphql_connect_example"></a><a class="link" href="#_complete_graphql_connect_example">8.2.3. Complete GraphQL Connect Example</a></h4>
@@ -6264,7 +6334,7 @@ and see the GraphQL equivalent been generated on the right.</p>
 <div id="footer">
 <div id="footer-text">
 Version 2<br>
-Last updated 2019-04-13 00:38:05 -03
+Last updated 2019-04-20 22:31:32 EDT
 </div>
 </div>
 </body>

--- a/src/com/wsscode/pathom/connect/graphql2.cljc
+++ b/src/com/wsscode/pathom/connect/graphql2.cljc
@@ -400,7 +400,7 @@
                          ::base-path              (vec (butlast (::p/path env)))
                          ::graphql-query          gq
                          ::errors                 (index-graphql-errors errors)}
-                        q)
+            q)
           (pull-idents)))))
 
 (defn graphql-mutation [{::keys [demung] :as config} env]
@@ -419,11 +419,11 @@
                                ::demung        (or demung identity)
                                ::graphql-query gq
                                ::errors        (index-graphql-errors errors)}
-                              (p/ast->query {:type     :root
-                                             :children [(assoc ast
-                                                               :type :join
-                                                               :key (keyword source-mutation)
-                                                               :dispatch-key (keyword source-mutation))]})))]
+                  (p/ast->query {:type     :root
+                                 :children [(assoc ast
+                                              :type :join
+                                              :key (keyword source-mutation)
+                                              :dispatch-key (keyword source-mutation))]})))]
         (get parser-response (keyword source-mutation))))))
 
 (defn defgraphql-resolver [{::pc/keys [resolver-dispatch mutate-dispatch]} {::keys [resolver] :as config}]


### PR DESCRIPTION
Solves https://github.com/wilkerlucio/pathom/issues/86 by allowing the user to pass a custom graphql inner parser to replace the built-in `parser-item`.