### PR TITLE
Convert sequential graphql params recursively.

### DIFF
--- a/src/com/wsscode/pathom/graphql.cljc
+++ b/src/com/wsscode/pathom/graphql.cljc
@@ -45,6 +45,9 @@
          (str "(" params ")")
          (str "{" params "}")))
 
+     (sequential? x)
+     (str "[" (str/join ", " (mapv #(params->graphql % js-name tempid? false) x)) "]")
+
      (symbol? x)
      (name x)
 

--- a/test/com/wsscode/pathom/graphql_test.cljc
+++ b/test/com/wsscode/pathom/graphql_test.cljc
@@ -28,6 +28,8 @@
     ; params
     '[(:parameterized {:foo "bar"})] "query { parameterized(foo: \"bar\") }"
 
+    '[(:parameterized {:foo [a b]})] "query { parameterized(foo: [a, b]) }"
+
     ; aliasing
     '[(:property {::pg/alias "aliased"})] "query { aliased: property }"
     '[{(:property {::pg/alias "aliased" :another "param"})


### PR DESCRIPTION
Before:
```clojure
=> (query->graphql '[(:parameterized {:foo [a b]})])
"query { parameterized(foo: [\"a\",\"b\"]) }"
```
After:
```clojure
=> (query->graphql '[(:parameterized {:foo [a b]})])
"query { parameterized(foo: [a, b]) }"
```