### PR TITLE
Fix graphql index generation when using `mung` and `demung`

### DIFF
--- a/src/com/wsscode/pathom/connect/graphql2.cljc
+++ b/src/com/wsscode/pathom/connect/graphql2.cljc
@@ -98,12 +98,12 @@
                          (->> schema :queryType :fields)))
         (as-> <>
           (reduce (fn [idx {:keys [name type]}]
-                    (let [params    (get ident-map name)
+                    (let [params    (get ident-map (mung name))
                           input-set (ident-map-params->io input params)]
                       (update idx input-set pc/merge-io {(ffirst (type->field-entry input type)) {}})))
             <>
             (->> schema :queryType :fields
-                 (filter (comp ident-map :name))))))))
+                 (filter (comp ident-map mung :name))))))))
 
 (defn args-translate [{::keys [prefix ident-map]} args]
   (or
@@ -122,9 +122,9 @@
                       {(args-translate input (:args %)) #{resolver}}))
               roots)
         (into (comp
-                (filter (comp ident-map :name))
+                (filter (comp ident-map mung :name))
                 (mapcat (fn [{:keys [type name]}]
-                          (let [params    (get ident-map name)
+                          (let [params    (get ident-map (mung name))
                                 input-set (ident-map-params->io input params)
                                 fields    (-> (get index-io #{(ffirst (type->field-entry input type))}) keys)]
                             (mapv (fn [field]
@@ -152,10 +152,10 @@
                              :as       env}]
   (let [schema (:__schema schema)
         fields (-> schema :queryType :fields)
-        idents (filter (comp ident-map :name) fields)]
+        idents (filter (comp ident-map mung :name) fields)]
     (-> {}
         (into (mapcat (fn [{:keys [name type]}]
-                        (let [params        (get ident-map name)
+                        (let [params        (get ident-map (mung name))
                               ident-key     (keyword (mung name) (mung (str/join "-and-" (keys params))))
                               entity-fields (mapv (fn [item] (ident-map-entry env item)) (vals params))
                               entity-field  (cond-> entity-fields (= 1 (count entity-fields)) first)


### PR DESCRIPTION
The main problem seemed to be trying to directly compare graphql introspection query names with names in the ident map. I instead call `mung` on names from the graphql schema before looking them up in the indent map.

I mimicked your test graphql schema, converting everything in the graphql schema to snake case and using kebab case as the munged form, to test. I also have confirmed that resolving ident joins with the graphql resolver in my own project work with this branch.

Of course, I'm happy to oblige if you'd like to see any changes.