### PR TITLE
Fixing ClassCastException in error-handler plugin

### DIFF
--- a/src/com/wsscode/pathom/core.cljc
+++ b/src/com/wsscode/pathom/core.cljc
@@ -828,7 +828,7 @@
   (fn wrap-parser-exception-internal [env tx]
     (let [errors (atom {})]
       (let-chan [res (parser (assoc env ::errors* errors) tx)]
-        (cond-> (if (keyword? res) {} res)
+        (cond-> (if (map? res) res {})
           (seq @errors) (assoc ::errors @errors))))))
 
 (def error-handler-plugin

--- a/src/com/wsscode/pathom/core.cljc
+++ b/src/com/wsscode/pathom/core.cljc
@@ -828,7 +828,7 @@
   (fn wrap-parser-exception-internal [env tx]
     (let [errors (atom {})]
       (let-chan [res (parser (assoc env ::errors* errors) tx)]
-        (cond-> res
+        (cond-> (if (keyword? res) {} res)
           (seq @errors) (assoc ::errors @errors))))))
 
 (def error-handler-plugin

--- a/test/com/wsscode/pathom/connect_test.cljc
+++ b/test/com/wsscode/pathom/connect_test.cljc
@@ -3314,6 +3314,16 @@
                 [{[:id 123]
                   [:c :d]}]))))
 
+     (testing "global resolver times out"
+       (is (= {:com.wsscode.pathom.core/errors {nil "class clojure.lang.ExceptionInfo: Parallel read timeout - {:timeout 200}"}}
+              (quick-parser {::p/env       {::pp/key-process-timeout 200}
+                             ::pc/register [(pc/resolver 'a
+                                                         {::pc/input  #{}
+                                                          ::pc/output [:whatever]}
+                                                         (fn [_ _]
+                                                           {:whatever (Thread/sleep 210)}))]}
+                            [:whatever]))))
+
      (testing "rename ident reads"
        (is (= (async/<!!
                 (parser-p {}


### PR DESCRIPTION
Hi,

we encountered  a weird bug during using Pathom in our services. We are using parallel-parsers with `key-process-timeout` set to 5000ms together with `error-handler-plugin`. We have couple of resolvers set up but when one of them times out (we are calling upstreams from them) on the highest level we get `ClassCastException` from `wrap-parser-exception` fn as the parser returns with `::p/reader-error` keyword return by `add-error` fn.
This is a pretty naive fix and does not fix the root cause as I believe the result of the parser should be always a map. But in order to fix that I would require a deeper knowledge of the code base and I just wanted to give a heads up that this issue exists.

Janos