### PR TITLE
Fix UUID and tempid handling in graphql queries

### DIFF
--- a/src/com/wsscode/pathom/connect/graphql2.cljc
+++ b/src/com/wsscode/pathom/connect/graphql2.cljc
@@ -331,8 +331,11 @@
 
 (defn query->graphql
   "Like the pg/query-graphql, but adds name convertion so clj names like :first-name turns in firstName."
-  [query {::keys [demung] :or {demung identity}}]
-  (pg/query->graphql query {::pg/js-name (comp demung name)}))
+  [query {::keys [demung tempid?]
+          :or {demung identity
+               tempid? (constantly false)}}]
+  (pg/query->graphql query {::pg/js-name (comp demung name)
+                            ::pg/tempid? tempid?}))
 
 (defn ast->graphql [{:keys     [ast]
                      ::pc/keys [indexes]}

--- a/src/com/wsscode/pathom/graphql.cljc
+++ b/src/com/wsscode/pathom/graphql.cljc
@@ -30,7 +30,8 @@
 (defn stringify [x]
   #?(:clj  (json/write-str (cond-> x
                              (uuid? x) str))
-     :cljs (js/JSON.stringify (clj->js x))))
+     :cljs (js/JSON.stringify (cond-> (clj->js x)
+                                (uuid? x) str))))
 
 (defn params->graphql
   ([x js-name tempid?] (params->graphql x js-name tempid? true))

--- a/test/com/wsscode/pathom/graphql_test.cljc
+++ b/test/com/wsscode/pathom/graphql_test.cljc
@@ -5,7 +5,8 @@
     [com.wsscode.pathom.graphql :as pg]
     [clojure.string :as str]
     [fulcro.client.primitives :as fp]
-    [edn-query-language.core :as eql]))
+    [edn-query-language.core :as eql])
+  #?(:clj (:import [java.util UUID])))
 
 (defn query->graphql [query]
   (-> (pg/query->graphql query {::pg/tempid? fp/tempid?})
@@ -14,6 +15,10 @@
 
 (defn aliased [alias key]
   (eql/update-property-param key assoc ::pg/alias alias))
+
+(defn uuid* [s]
+  #?(:clj (UUID/fromString s)
+     :cljs (uuid s)))
 
 (deftest test-query->graphql
   (are [query out] (= (query->graphql query) out)
@@ -29,6 +34,9 @@
     '[(:parameterized {:foo "bar"})] "query { parameterized(foo: \"bar\") }"
 
     '[(:parameterized {:foo [a b]})] "query { parameterized(foo: [a, b]) }"
+
+    `[(:parameterized {:foo ~(uuid* "ead34300-0ef6-4c31-9626-90bf18fa22c0")})]
+    "query { parameterized(foo: \"ead34300-0ef6-4c31-9626-90bf18fa22c0\") }"
 
     ; aliasing
     '[(:property {::pg/alias "aliased"})] "query { aliased: property }"


### PR DESCRIPTION
Fixes clojurescript formatting of UUIDs in graphql parameters.
```clojure
;; Before
cljs.user> (js/JSON.stringify (clj->js (random-uuid)))
"{\"uuid\":\"f03af9f4-4dec-4c77-b66c-9e1e2ca0f8a4\",\"__hash\":null,\"cljs$lang$protocol_mask$partition0$\":2153775104,\"cljs$lang$protocol_mask$partition1$\":2048}"
;; After
cljs.user> (js/JSON.stringify (str (clj->js (random-uuid))))
"\"1e2e14f3-aa82-4579-badb-a3684158d80d\""
```

Also allows pathom connect graphql to pass through a `tempid?` config param.