### PR TITLE
Remove ::p/env from mutations when there is no join

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [2.2.29]
 - `pc/reader2` will return `::p/not-found` instead of an error when dependency links are missing
+- `::p/env` is automatically removed from mutations that return it and have no query 
 
 ## [2.2.28]
 - Fix bounded recursion on parallel parser

--- a/src/com/wsscode/pathom/connect.cljc
+++ b/src/com/wsscode/pathom/connect.cljc
@@ -1508,7 +1508,7 @@
                   (if (and query (map? res))
                     (merge (select-keys res mutation-join-globals)
                            (p/join (atom res) (assoc env ::mutation-ast ast)))
-                    res))})
+                    (dissoc res ::p/env)))})
     (throw (ex-info "Mutation not found" {:mutation sym'}))))
 
 (defn mutate-async
@@ -1525,7 +1525,7 @@
                     (if query
                       (merge (select-keys res mutation-join-globals)
                              (<? (p/join (atom res) (assoc env ::mutation-ast ast))))
-                      res)))})
+                      (dissoc res ::p/env))))})
     (throw (ex-info "Mutation not found" {:mutation sym'}))))
 
 ;;;;;;;;;;;;;;;;;;;

--- a/test/com/wsscode/pathom/connect_test.cljc
+++ b/test/com/wsscode/pathom/connect_test.cljc
@@ -3308,7 +3308,14 @@
                                                  ::pc/output [:y]}
                                                 (fn [_ _] {:y true}))]}
            [:y])
-         {:y ::p/not-found})))
+         {:y ::p/not-found}))
+
+  (testing "elide env from mutation when user sends no query"
+    (is (= (quick-parser-serial {::pc/register [(pc/mutation 'x
+                                                  {}
+                                                  (fn [env _] {::p/env env}))]}
+             '[(x {})])
+           '{x {}}))))
 
 #?(:clj
    (deftest test-parallel-parser-with-connect
@@ -3521,6 +3528,13 @@
                 (parser-p {}
                   [:provide-env ::pc/env]))
               {:provide-env "x" ::pc/env ::p/not-found})))
+
+     (testing "elide env from mutation when user sends no query"
+       (is (= (quick-parser {::pc/register [(pc/mutation 'x
+                                              {}
+                                              (fn [env _] {::p/env env}))]}
+                '[(x {})])
+              '{x {}})))
 
      (testing "regressions"
        (testing "parallel bounded recursions"


### PR DESCRIPTION
Closes #135 