### PR TITLE
Fixes ::pc/transform spec

### DIFF
--- a/src/com/wsscode/pathom/connect.cljc
+++ b/src/com/wsscode/pathom/connect.cljc
@@ -121,7 +121,7 @@
                    :graph-plan ::pcp/graph))
 
 (>def ::sort-plan (s/fspec :args (s/cat :env ::p/env :plan ::plan-path)))
-(>def ::transform fn?)
+(>def ::transform ifn?)
 
 (>def ::reader3-computed-plans
   "A set containing the paths where reader3 was already processed, this allows recursive

--- a/test/com/wsscode/pathom/connect_test.cljc
+++ b/test/com/wsscode/pathom/connect_test.cljc
@@ -363,6 +363,14 @@
   (is (= (::pc/output resolver-from-macro)
          [:bar])))
 
+(pc/defresolver resolver-with-transform [_ _]
+  {::pc/transform identity ::pc/output [:foo]}
+  {:foo "bar"})
+
+(deftest resolver-with-transform-test
+  (is (= (::pc/output resolver-with-transform)
+         [:foo])))
+
 (deftest test-add
   (testing "simple add"
     (is (= (pc/add {} 'user-by-login


### PR DESCRIPTION
Hi, this PR fixes the spec for `::pc/transform`. With the spec previously being `fn?`, the test I included would fail due to `identity` not fulfilling `fn?` (its type was `clojure.lang.Symbol`). Thanks and let me know if there's anything you'd like changed!