### PR TITLE
aot compilation fix (extraction refactorings)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.jar
 .rebl
 .cpcache
+.clj-kondo/.cache
+.lsp
+.calva/output-window
 .DS_Store
 .hg/
 .hgignore


### PR DESCRIPTION
Attempt to fix #187. Just a proof-of-concept for the solution, really.

This branch is a fork of `2.3.1` tag and passes a "aot-all compilation test":

```bash
lein clean && lein update-in : assoc :aot :all -- install
```

I'm affraid that I didn't provide the best possible function names as I don't have insight of pathom's internal structure. To anyone reading this: feel free to fork-modify this PR and/or open your own PR as needed.